### PR TITLE
feat: add urls field to findScenesCompact query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stashapp-api",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stashapp-api",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "license": "MIT",
       "dependencies": {
         "graphql": "^16.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stashapp-api",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Easy to use adapter for interaction with a Stash server through GraphQL.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operations/findScenesCompact.graphql
+++ b/src/operations/findScenesCompact.graphql
@@ -28,6 +28,7 @@ query FindScenesCompact(
       resume_time
       title
       updated_at
+      urls
       studio {
         id
         name


### PR DESCRIPTION
## Summary
- Adds the `urls` field to the `findScenesCompact` GraphQL query
- Required for peek-stash-browser issue #195 (scene URLs display)

## Test plan
- [x] `npm run refresh` succeeds
- [x] Package published as 0.3.22

🤖 Generated with [Claude Code](https://claude.com/claude-code)